### PR TITLE
Fix deprecation warnings on Extractor.hx and Validator.hx

### DIFF
--- a/src/tink/validation/Extractor.hx
+++ b/src/tink/validation/Extractor.hx
@@ -11,7 +11,7 @@ class ExtractorBase {
 	public function new() {}
 	
 	function extractInt64(value:Dynamic) {
-		if(Int64.is(value)) return value;
+		if(Int64.isInt64(value)) return value;
 		
 		if(Std.is(value, Int)) {
 			var v:Int = value;

--- a/src/tink/validation/Validator.hx
+++ b/src/tink/validation/Validator.hx
@@ -11,7 +11,7 @@ class ValidatorBase {
 	public function new() {}
 	
 	function validateInt64(value:Dynamic) {
-		if(Int64.is(value)) return;
+		if(Int64.isInt64(value)) return;
 		
 		// if(Std.is(value, Int)) {
 		// 	return;


### PR DESCRIPTION
This is a minor PR that change `Int64.is` calls to `Int64.isInt64` to get rid of the depreciation warnings.